### PR TITLE
Correctly resolve imported TypeScript files

### DIFF
--- a/test/configs/wdio.integration.conf.ts
+++ b/test/configs/wdio.integration.conf.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { baseConfig } from './baseConfig.ts';
+import { baseConfig } from './baseConfig.js';
 import { getAllFilesSync } from 'get-all-files';
 import { fileURLToPath } from 'url';
 

--- a/test/configs/wdio.record.conf.ts
+++ b/test/configs/wdio.record.conf.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import * as fs from 'fs';
-import baseConfig from './baseConfig';
+import { baseConfig } from './baseConfig.js';
 import nock from 'nock';
 
 const appendLogToFile = (content) => fs.appendFileSync('record.txt', content);

--- a/test/pageobjects/login.page.ts
+++ b/test/pageobjects/login.page.ts
@@ -1,5 +1,5 @@
-import Page from './page';
-import { BrowsingContextNavigateResult } from '../node_modules/webdriver/build/bidi/localTypes';
+import Page from './page.js';
+import { BrowsingContextNavigateResult } from '../node_modules/webdriver/build/bidi/localTypes.js';
 
 /**
  * sub page containing specific selectors and methods for a specific page

--- a/test/specs/baseTest.ts
+++ b/test/specs/baseTest.ts
@@ -1,4 +1,4 @@
-import LoginPage from '../pageobjects/login.page';
+import LoginPage from '../pageobjects/login.page.js';
 
 export default function () {
     beforeAll(() => {


### PR DESCRIPTION
### What has been done?

- Added `.js` extensions to imported TypeScript files

### Why was this done?

- TypeScript doesn't rewrite `*.ts` files to having `*.js` extensions. https://github.com/microsoft/TypeScript/issues/49083

### How to test the changes?

1. `yarn test` should now run without throwing compiler issues (although that does not mean the tests themselves already pass)

